### PR TITLE
Fixed warning about node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: 'File to upload. Does not support wildcards.'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/djn24/add-asset-to-release.git"


### PR DESCRIPTION
Github Action throws this warning at the moment: 
![image](https://github.com/djn24/add-asset-to-release/assets/248805/29d3f5c2-6132-4975-85c0-01e683390941)

the code seems definitely compatible with 16 so you shouldn't have any problems. I don't know how to test it in all honesty.
